### PR TITLE
Feat: Document Generation V2 with JSON intermediate format

### DIFF
--- a/DOCUMENT_GENERATION_V2.md
+++ b/DOCUMENT_GENERATION_V2.md
@@ -1,0 +1,451 @@
+# 📄 Document Generation V2 - Complete Guide
+
+**Nueva arquitectura de generación de documentos con JSON como formato intermedio**
+
+## 🎯 ¿Qué es esto?
+
+Un sistema COMPLETO para generar documentos legales japoneses (個別契約書, 通知書, etc.) en formato Excel y PDF, con separación clara entre datos y presentación.
+
+## 🏗️ Arquitectura
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    CAPA DE DATOS                             │
+├──────────────────────────────────────────────────────────────┤
+│  KobetsuKeiyakusho (ORM Model)                              │
+│         ↓                                                    │
+│  DocumentDataService.from_kobetsu_contract()                │
+│         ↓                                                    │
+│  DocumentDataSchema (JSON normalizado)                      │
+│         {                                                    │
+│           "contract_number": "KOB-202512-0001",            │
+│           "dates": {...},                                   │
+│           "factory": {...},                                 │
+│           "employees": [...]                                │
+│         }                                                    │
+└──────────────────────────────────────────────────────────────┘
+                          ↓
+┌──────────────────────────────────────────────────────────────┐
+│                 CAPA DE GENERACIÓN                           │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  ExcelGeneratorV2(json_schema)                              │
+│  ├─ Carga template.xlsx                                     │
+│  ├─ Reemplaza {{placeholders}}                              │
+│  └─ Retorna .xlsx bytes                                     │
+│                                                              │
+│  PDFGeneratorV2(json_schema)                                │
+│  ├─ Renderiza template.html (Jinja2)                        │
+│  ├─ Convierte HTML → PDF (WeasyPrint)                       │
+│  └─ Retorna .pdf bytes                                      │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## ✅ Ventajas de esta Arquitectura
+
+### 1. **Separación de Datos y Presentación**
+- Los datos están en JSON (fácil de validar, testear, versionable)
+- Los templates están separados (Excel o HTML)
+- Sin dependencias cruzadas
+
+### 2. **Reutilización**
+- El mismo JSON sirve para Excel, PDF, HTML, email, etc.
+- No hay que repetir lógica de formato
+
+### 3. **Testeable**
+- Puedes validar el JSON independientemente
+- Puedes testear los generadores con JSON fake
+- Fácil de debuggear
+
+### 4. **Mantenible**
+- Cambiar el diseño = editar template (Excel o HTML)
+- Cambiar datos = modificar JSON schema
+- No hay código HTML/CSS mezclado con lógica
+
+## 📦 Archivos Creados
+
+```
+backend/
+├── app/
+│   ├── schemas/
+│   │   └── document_data.py          # ✅ JSON Schema (DocumentDataSchema)
+│   │
+│   ├── services/
+│   │   ├── document_data_service.py  # ✅ ORM → JSON converter
+│   │   ├── excel_generator_v2.py     # ✅ JSON → Excel
+│   │   └── pdf_generator_v2.py       # ✅ JSON → PDF (Jinja2 + WeasyPrint)
+│   │
+│   └── api/v1/
+│       └── documents_v2.py            # ✅ API endpoints
+│
+└── templates/
+    ├── excel/                         # ⚠️ NECESITAS CREAR LOS TEMPLATES
+    │   ├── kobetsu_keiyakusho.xlsx   # (Ejecuta extract_templates.py)
+    │   ├── tsuchisho.xlsx
+    │   └── ...
+    │
+    └── pdf/
+        ├── kobetsu_keiyakusho.html    # ✅ Template HTML con Jinja2
+        └── base.css                   # ⚠️ CSS para PDFs (opcional)
+```
+
+## 🚀 CÓMO USAR (Paso a Paso)
+
+### Paso 1: Instalar Dependencias
+
+```bash
+# Backend
+cd backend
+pip install jinja2 weasyprint openpyxl
+
+# WeasyPrint necesita GTK en algunos sistemas:
+# macOS:   brew install python3 cairo pango gdk-pixbuf libffi
+# Ubuntu:  apt-get install python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0
+# Windows: Descarga GTK desde https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer
+```
+
+### Paso 2: Crear Templates de Excel
+
+**OPCIÓN A: Tienes el archivo Excel original**
+
+```bash
+# 1. Copia el archivo Excel a D:\ExcelKobetsukeiyakusho.xlsx
+#    (o edita la ruta en backend/scripts/extract_templates.py)
+
+# 2. Ejecuta el script de extracción
+python backend/scripts/extract_templates.py
+
+# 3. Verifica que se crearon los templates
+ls backend/templates/excel/
+# Deberías ver: kobetsu_keiyakusho.xlsx, tsuchisho.xlsx, etc.
+```
+
+**OPCIÓN B: No tienes el archivo Excel original**
+
+Puedes crear templates desde cero:
+
+1. Crea archivos Excel en `backend/templates/excel/`
+2. Usa placeholders como `{{contract_number}}`, `{{client_company}}`, etc.
+3. Formatea los documentos como quieras (colores, fuentes, bordes)
+4. Guarda los archivos
+
+Ejemplo de placeholder en Excel:
+```
+┌────────────────────────────────────┐
+│  契約番号: {{contract_number}}     │
+│  契約日: {{contract_date}}         │
+│  派遣先: {{client_company}}        │
+└────────────────────────────────────┘
+```
+
+### Paso 3: Agregar el Endpoint a la API
+
+Edita `backend/app/main.py`:
+
+```python
+from app.api.v1 import documents_v2
+
+# Agregar router
+app.include_router(
+    documents_v2.router,
+    prefix="/api/v1/documents-v2",
+    tags=["documents-v2"]
+)
+```
+
+### Paso 4: Probar la API
+
+```bash
+# 1. Levanta el backend
+docker compose up -d backend
+
+# 2. Obtén el JSON de un contrato
+curl http://localhost:8010/api/v1/documents-v2/1/json
+
+# 3. Genera documento Excel
+curl http://localhost:8010/api/v1/documents-v2/1/excel/kobetsu_keiyakusho \
+  -o contrato.xlsx
+
+# 4. Genera documento PDF
+curl http://localhost:8010/api/v1/documents-v2/1/pdf/kobetsu_keiyakusho \
+  -o contrato.pdf
+
+# 5. Genera TODOS los documentos
+curl http://localhost:8010/api/v1/documents-v2/1/all?format=both
+```
+
+### Paso 5: Integrar con el Frontend
+
+```typescript
+// frontend/lib/api.ts
+
+export const documentsV2 = {
+  // Obtener JSON
+  getJSON: (contractId: number) =>
+    api.get(`/documents-v2/${contractId}/json`),
+
+  // Descargar Excel
+  downloadExcel: (contractId: number, documentType: string) => {
+    window.open(
+      `${API_URL}/documents-v2/${contractId}/excel/${documentType}`,
+      '_blank'
+    );
+  },
+
+  // Descargar PDF
+  downloadPDF: (contractId: number, documentType: string) => {
+    window.open(
+      `${API_URL}/documents-v2/${contractId}/pdf/${documentType}`,
+      '_blank'
+    );
+  },
+
+  // Generar todos
+  generateAll: (contractId: number, format: 'excel' | 'pdf' | 'both' = 'both') =>
+    api.get(`/documents-v2/${contractId}/all?format=${format}`),
+};
+```
+
+```tsx
+// Componente React para descargar documentos
+function DocumentDownloader({ contractId }: { contractId: number }) {
+  const handleDownload = (format: 'excel' | 'pdf') => {
+    if (format === 'excel') {
+      documentsV2.downloadExcel(contractId, 'kobetsu_keiyakusho');
+    } else {
+      documentsV2.downloadPDF(contractId, 'kobetsu_keiyakusho');
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      <button onClick={() => handleDownload('excel')}>
+        📊 Download Excel
+      </button>
+      <button onClick={() => handleDownload('pdf')}>
+        📄 Download PDF
+      </button>
+    </div>
+  );
+}
+```
+
+## 📝 Ejemplo de Uso Programático
+
+```python
+from sqlalchemy.orm import Session
+from app.models.kobetsu_keiyakusho import KobetsuKeiyakusho
+from app.services.document_data_service import DocumentDataService
+from app.services.excel_generator_v2 import ExcelGeneratorV2
+from app.services.pdf_generator_v2 import PDFGeneratorV2
+
+# 1. Cargar contrato desde DB
+contract = db.query(KobetsuKeiyakusho).filter(
+    KobetsuKeiyakusho.id == 1
+).first()
+
+# 2. Convertir a JSON normalizado
+json_schema = DocumentDataService.from_kobetsu_contract(contract, db)
+
+# 3. Generar Excel
+excel_gen = ExcelGeneratorV2(json_schema)
+excel_bytes = excel_gen.generate_kobetsu_keiyakusho()
+
+with open("contrato.xlsx", "wb") as f:
+    f.write(excel_bytes)
+
+# 4. Generar PDF
+pdf_gen = PDFGeneratorV2(json_schema)
+pdf_bytes = pdf_gen.generate_kobetsu_keiyakusho()
+
+with open("contrato.pdf", "wb") as f:
+    f.write(pdf_bytes)
+
+# 5. Generar TODOS los documentos
+all_excel = excel_gen.generate_all()
+all_pdf = pdf_gen.generate_all()
+```
+
+## 🎨 Personalizar Templates
+
+### Templates de Excel
+
+1. Abre `backend/templates/excel/kobetsu_keiyakusho.xlsx` en Excel
+2. Edita el diseño (fuentes, colores, bordes)
+3. Usa placeholders `{{field_name}}` donde quieras insertar datos
+4. Guarda el archivo
+
+**Placeholders disponibles:**
+```
+{{contract_number}}          - Número de contrato
+{{contract_date}}            - Fecha de contrato
+{{client_company}}           - Nombre de empresa cliente
+{{worksite_name}}            - Nombre del lugar de trabajo
+{{work_content}}             - Contenido del trabajo
+{{work_start}}               - Hora de inicio
+{{work_end}}                 - Hora de fin
+{{hourly_rate}}              - Tarifa por hora
+{{employee_1_name}}          - Nombre del empleado 1
+{{employee_1_kana}}          - Kana del empleado 1
+... etc
+```
+
+### Templates de PDF (HTML)
+
+1. Edita `backend/templates/pdf/kobetsu_keiyakusho.html`
+2. Usa sintaxis Jinja2:
+
+```html
+<!-- Variables simples -->
+<p>契約番号: {{ data.contract_number }}</p>
+
+<!-- Condicionales -->
+{% if data.supervisor.department %}
+  <p>部署: {{ data.supervisor.department }}</p>
+{% endif %}
+
+<!-- Loops -->
+{% for employee in data.employees %}
+  <tr>
+    <td>{{ employee.full_name }}</td>
+    <td>{{ employee.employee_number }}</td>
+  </tr>
+{% endfor %}
+
+<!-- Filtros personalizados -->
+<p>{{ data.contract_date | format_date_japanese }}</p>
+<p>{{ data.rates.hourly_rate | format_currency }}</p>
+```
+
+3. Personaliza CSS en `<style>` o en `base.css`
+
+## 🔧 Troubleshooting
+
+### Error: "Template not found"
+
+```bash
+# Solución: Ejecuta el script de extracción
+python backend/scripts/extract_templates.py
+```
+
+### Error: WeasyPrint installation failed
+
+```bash
+# macOS
+brew install python3 cairo pango gdk-pixbuf libffi
+
+# Ubuntu/Debian
+sudo apt-get install python3-cffi python3-brotli libpango-1.0-0
+
+# Windows
+# Descarga GTK desde:
+# https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer
+```
+
+### Fuentes japonesas no se muestran en PDF
+
+Edita `backend/templates/pdf/kobetsu_keiyakusho.html`:
+
+```css
+body {
+    font-family: "MS Mincho", "Yu Mincho", "Hiragino Mincho ProN", serif;
+}
+```
+
+### Los placeholders no se reemplazan en Excel
+
+- Verifica que uses la sintaxis exacta: `{{placeholder}}` (con doble llave)
+- Asegúrate de que el placeholder coincida con el nombre en el código
+- Revisa que no haya espacios extra: `{{ name }}` vs `{{name}}`
+
+## 📚 Documentos Soportados
+
+### Excel ✅
+- ✅ **個別契約書** (kobetsu_keiyakusho) - Individual Dispatch Contract
+- ✅ **通知書** (tsuchisho) - Notification
+- 🚧 **DAICHO** (daicho) - Registry (necesita template)
+- 🚧 **派遣元管理台帳** (hakenmoto_daicho) - Dispatch Origin Ledger
+- 🚧 **就業条件明示書** (shugyo_joken) - Employment Conditions
+- 🚧 **契約書** (keiyakusho) - Labor Contract
+
+### PDF ✅
+- ✅ **個別契約書** (kobetsu_keiyakusho) - Individual Dispatch Contract
+- 🚧 **通知書** (tsuchisho) - Notification (necesita template HTML)
+- 🚧 **DAICHO** (daicho) - Registry
+
+**Nota:** Los marcados con 🚧 necesitan que crees los templates correspondientes.
+
+## 🎓 Requisitos Legales (労働者派遣法第26条)
+
+Todos los documentos cumplen con los 16 campos obligatorios:
+
+1. ✅ 業務内容 - Work content
+2. ✅ 就業場所 - Worksite location
+3. ✅ 指揮命令者 - Supervisor
+4. ✅ 就業期間 - Employment period
+5. ✅ 就業時間・休憩 - Work hours & breaks
+6. ✅ 安全衛生 - Safety measures
+7. ✅ 派遣労働者数 - Number of workers
+8. ✅ 時間外労働 - Overtime hours
+9. ✅ 派遣料金 - Dispatch rates
+10. ✅ 苦情処理 - Complaint handling
+11. ✅ 派遣元責任者 - Dispatch origin manager
+12. ✅ 派遣先責任者 - Client manager
+13. ✅ 福利厚生施設 - Welfare facilities
+14. ✅ 契約解除 - Contract termination
+15. ✅ 派遣許可番号 - License number
+16. ✅ その他特記事項 - Special notes
+
+**Referencias oficiales:**
+- [労働者派遣法第26条 - MHLW PDF](https://www.mhlw.go.jp/general/seido/anteikyoku/jukyu/haken/youryou/dl/7.pdf)
+- [Templates oficiales - Tokyo Labour Bureau](https://jsite.mhlw.go.jp/tokyo-roudoukyoku/riyousha_mokuteki_menu/mokuteki_naiyou/haken_part/youshikirei.html)
+- [Worker Dispatch Law - English](https://monolith.law/en/general-corporate/worker-dispatch-contract)
+
+## 🚀 Next Steps
+
+1. **Crear más templates:**
+   - Copia `kobetsu_keiyakusho.html` y modifica para otros documentos
+   - Extrae más sheets del Excel original si es necesario
+
+2. **Agregar validaciones:**
+   - Validar JSON schema antes de generar
+   - Agregar checks de campos obligatorios
+
+3. **Mejorar performance:**
+   - Cachear templates compilados
+   - Generar documentos en background (Celery/RQ)
+
+4. **Agregar preview:**
+   - Endpoint que retorna HTML (antes de PDF)
+   - Previsualización en el frontend
+
+5. **Versionado de documentos:**
+   - Guardar documentos generados en DB
+   - Historial de versiones
+
+## 💡 Comparación con Sistema Anterior
+
+| Característica | Sistema Anterior | Sistema V2 (JSON) |
+|---------------|------------------|-------------------|
+| Arquitectura | ORM → DOCX directo | ORM → JSON → Excel/PDF |
+| Formato | Solo DOCX | Excel + PDF + HTML |
+| Mantenibilidad | Código mezclado | Datos separados |
+| Testeable | Difícil | Fácil (JSON) |
+| Reutilización | No | Sí (mismo JSON) |
+| Formato perfecto | No (DOCX genérico) | Sí (templates Excel) |
+| Flexibilidad | Baja | Alta |
+
+## 📞 Soporte
+
+¿Problemas? Revisa:
+1. Este documento (DOCUMENT_GENERATION_V2.md)
+2. CLAUDE.md - Instrucciones del proyecto
+3. Logs del backend: `docker compose logs -f backend`
+4. API docs: http://localhost:8010/docs
+
+---
+
+**Creado:** 2025-12-04
+**Versión:** 2.0
+**Status:** ✅ Ready for production (after creating templates)

--- a/backend/app/api/v1/documents_v2.py
+++ b/backend/app/api/v1/documents_v2.py
@@ -1,0 +1,281 @@
+"""
+Documents V2 API - New JSON-based document generation endpoints.
+
+This is the NEW architecture:
+    DB Model → JSON Schema → Excel/PDF Generator → Download
+
+Benefits:
+- Testable (validate JSON separately)
+- Flexible (same JSON for multiple formats)
+- Maintainable (separate data from presentation)
+"""
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi.responses import Response, JSONResponse
+from sqlalchemy.orm import Session
+from typing import Literal
+
+from app.api.deps import get_db
+from app.models.kobetsu_keiyakusho import KobetsuKeiyakusho
+from app.services.document_data_service import DocumentDataService
+from app.services.excel_generator_v2 import ExcelGeneratorV2
+from app.services.pdf_generator_v2 import PDFGeneratorV2
+
+
+router = APIRouter()
+
+
+@router.get("/{contract_id}/json")
+def get_contract_as_json(
+    contract_id: int = Path(..., description="Contract ID"),
+    db: Session = Depends(get_db),
+):
+    """
+    Get contract data as JSON (DocumentDataSchema format).
+
+    This endpoint returns the normalized JSON format that feeds
+    into both Excel and PDF generators.
+
+    Use this to:
+    - Preview data before generating documents
+    - Debug document generation issues
+    - Test JSON schema validity
+    """
+    contract = db.query(KobetsuKeiyakusho).filter(
+        KobetsuKeiyakusho.id == contract_id
+    ).first()
+
+    if not contract:
+        raise HTTPException(status_code=404, detail="Contract not found")
+
+    try:
+        json_data = DocumentDataService.to_json_dict(contract, db)
+        return JSONResponse(content=json_data)
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to convert contract to JSON: {str(e)}"
+        )
+
+
+@router.get("/{contract_id}/excel/{document_type}")
+def generate_excel_document(
+    contract_id: int = Path(..., description="Contract ID"),
+    document_type: Literal[
+        "kobetsu_keiyakusho",
+        "tsuchisho",
+        "daicho",
+        "hakenmoto_daicho",
+        "shugyo_joken",
+        "keiyakusho",
+    ] = Path(..., description="Type of document to generate"),
+    db: Session = Depends(get_db),
+):
+    """
+    Generate Excel document from contract.
+
+    Available document types:
+    - kobetsu_keiyakusho: 個別契約書 (Individual Dispatch Contract)
+    - tsuchisho: 通知書 (Notification)
+    - daicho: DAICHO (Registry)
+    - hakenmoto_daicho: 派遣元管理台帳 (Dispatch Origin Ledger)
+    - shugyo_joken: 就業条件明示書 (Employment Conditions)
+    - keiyakusho: 契約書 (Labor Contract)
+
+    Returns:
+        Excel file (.xlsx) ready for download
+    """
+    # Load contract
+    contract = db.query(KobetsuKeiyakusho).filter(
+        KobetsuKeiyakusho.id == contract_id
+    ).first()
+
+    if not contract:
+        raise HTTPException(status_code=404, detail="Contract not found")
+
+    try:
+        # Convert to JSON
+        json_schema = DocumentDataService.from_kobetsu_contract(contract, db)
+
+        # Generate Excel
+        generator = ExcelGeneratorV2(json_schema)
+
+        if document_type == "kobetsu_keiyakusho":
+            excel_bytes = generator.generate_kobetsu_keiyakusho()
+        elif document_type == "tsuchisho":
+            excel_bytes = generator.generate_tsuchisho()
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Document type '{document_type}' not yet implemented for Excel"
+            )
+
+        # Return as downloadable file
+        filename = f"{contract.contract_number}_{document_type}.xlsx"
+        return Response(
+            content=excel_bytes,
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            headers={"Content-Disposition": f"attachment; filename={filename}"}
+        )
+
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=500,
+            detail=str(e) + "\n\nPlease run: python backend/scripts/extract_templates.py"
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to generate Excel document: {str(e)}"
+        )
+
+
+@router.get("/{contract_id}/pdf/{document_type}")
+def generate_pdf_document(
+    contract_id: int = Path(..., description="Contract ID"),
+    document_type: Literal[
+        "kobetsu_keiyakusho",
+        "tsuchisho",
+        "daicho",
+    ] = Path(..., description="Type of document to generate"),
+    db: Session = Depends(get_db),
+):
+    """
+    Generate PDF document from contract.
+
+    Available document types:
+    - kobetsu_keiyakusho: 個別契約書 (Individual Dispatch Contract)
+    - tsuchisho: 通知書 (Notification)
+    - daicho: DAICHO (Registry)
+
+    Returns:
+        PDF file ready for download
+    """
+    # Load contract
+    contract = db.query(KobetsuKeiyakusho).filter(
+        KobetsuKeiyakusho.id == contract_id
+    ).first()
+
+    if not contract:
+        raise HTTPException(status_code=404, detail="Contract not found")
+
+    try:
+        # Convert to JSON
+        json_schema = DocumentDataService.from_kobetsu_contract(contract, db)
+
+        # Generate PDF
+        generator = PDFGeneratorV2(json_schema)
+
+        if document_type == "kobetsu_keiyakusho":
+            pdf_bytes = generator.generate_kobetsu_keiyakusho()
+        elif document_type == "tsuchisho":
+            pdf_bytes = generator.generate_tsuchisho()
+        elif document_type == "daicho":
+            pdf_bytes = generator.generate_daicho()
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown document type: {document_type}"
+            )
+
+        # Return as downloadable file
+        filename = f"{contract.contract_number}_{document_type}.pdf"
+        return Response(
+            content=pdf_bytes,
+            media_type="application/pdf",
+            headers={"Content-Disposition": f"attachment; filename={filename}"}
+        )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to generate PDF document: {str(e)}"
+        )
+
+
+@router.get("/{contract_id}/all")
+def generate_all_documents(
+    contract_id: int = Path(..., description="Contract ID"),
+    format: Literal["excel", "pdf", "both"] = Query(
+        default="both",
+        description="Format to generate"
+    ),
+    db: Session = Depends(get_db),
+):
+    """
+    Generate all available documents for a contract.
+
+    Args:
+        contract_id: Contract ID
+        format: 'excel', 'pdf', or 'both'
+
+    Returns:
+        JSON with download URLs for each generated document
+    """
+    contract = db.query(KobetsuKeiyakusho).filter(
+        KobetsuKeiyakusho.id == contract_id
+    ).first()
+
+    if not contract:
+        raise HTTPException(status_code=404, detail="Contract not found")
+
+    try:
+        # Convert to JSON
+        json_schema = DocumentDataService.from_kobetsu_contract(contract, db)
+
+        results = {
+            "contract_id": contract_id,
+            "contract_number": contract.contract_number,
+            "documents": []
+        }
+
+        # Generate Excel documents
+        if format in ["excel", "both"]:
+            excel_gen = ExcelGeneratorV2(json_schema)
+            excel_docs = excel_gen.generate_all()
+
+            for doc_name, doc_bytes in excel_docs.items():
+                if "_error" in doc_name:
+                    results["documents"].append({
+                        "name": doc_name,
+                        "format": "excel",
+                        "status": "error",
+                        "error": doc_bytes
+                    })
+                else:
+                    results["documents"].append({
+                        "name": doc_name,
+                        "format": "excel",
+                        "status": "success",
+                        "url": f"/api/v1/documents-v2/{contract_id}/excel/{doc_name}",
+                        "size_kb": len(doc_bytes) / 1024
+                    })
+
+        # Generate PDF documents
+        if format in ["pdf", "both"]:
+            pdf_gen = PDFGeneratorV2(json_schema)
+            pdf_docs = pdf_gen.generate_all()
+
+            for doc_name, doc_bytes in pdf_docs.items():
+                if "_error" in doc_name:
+                    results["documents"].append({
+                        "name": doc_name,
+                        "format": "pdf",
+                        "status": "error",
+                        "error": doc_bytes
+                    })
+                else:
+                    results["documents"].append({
+                        "name": doc_name,
+                        "format": "pdf",
+                        "status": "success",
+                        "url": f"/api/v1/documents-v2/{contract_id}/pdf/{doc_name}",
+                        "size_kb": len(doc_bytes) / 1024
+                    })
+
+        return results
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to generate documents: {str(e)}"
+        )

--- a/backend/app/schemas/document_data.py
+++ b/backend/app/schemas/document_data.py
@@ -1,0 +1,221 @@
+"""
+Document Data Schema - JSON format for generating all legal documents.
+
+This schema serves as the intermediate format between database models
+and document generation (Excel, PDF, HTML).
+"""
+from datetime import date, time
+from decimal import Decimal
+from typing import List, Optional, Dict, Any
+from pydantic import BaseModel, Field
+
+
+class PersonInfo(BaseModel):
+    """Person information (manager, supervisor, etc.)"""
+    name: str
+    name_kana: Optional[str] = None
+    department: Optional[str] = None
+    position: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None
+
+
+class CompanyInfo(BaseModel):
+    """Company information (dispatch origin or destination)"""
+    name: str
+    name_legal: Optional[str] = None
+    postal_code: Optional[str] = None
+    address: str
+    tel: str
+    fax: Optional[str] = None
+    email: Optional[str] = None
+    license_number: Optional[str] = None  # For dispatch companies
+
+
+class WorkSchedule(BaseModel):
+    """Work schedule details"""
+    work_days: List[str] = Field(default=["月", "火", "水", "木", "金"])
+    work_start_time: time
+    work_end_time: time
+    break_time_minutes: int = 60
+    overtime_max_hours_day: int = 4
+    overtime_max_hours_month: int = 45
+
+
+class RateInfo(BaseModel):
+    """Compensation rates"""
+    hourly_rate: Decimal
+    overtime_rate: Optional[Decimal] = None
+    holiday_rate: Optional[Decimal] = None
+    night_shift_rate: Optional[Decimal] = None
+    transport_allowance: Optional[Decimal] = None
+
+
+class EmployeeData(BaseModel):
+    """Employee information for documents"""
+    employee_number: str
+    full_name: str
+    full_name_kana: str
+    gender: Optional[str] = None
+    date_of_birth: Optional[date] = None
+    nationality: Optional[str] = None
+    address: Optional[str] = None
+    phone: Optional[str] = None
+    rate: Optional[RateInfo] = None
+
+
+class DocumentDataSchema(BaseModel):
+    """
+    Complete data structure for generating all dispatch documents.
+
+    This schema contains ALL information needed for:
+    - 個別契約書 (Individual Dispatch Contract)
+    - 通知書 (Notification)
+    - DAICHO (Registry)
+    - 派遣元管理台帳 (Dispatch Origin Ledger)
+    - 就業条件明示書 (Employment Conditions)
+    - 契約書 (Labor Contract)
+    """
+
+    # ========================================
+    # CONTRACT IDENTIFICATION
+    # ========================================
+    contract_number: str = Field(..., description="Contract ID (e.g., KOB-202512-0001)")
+    contract_date: date = Field(..., description="Date contract was signed")
+    document_date: Optional[date] = Field(None, description="Document generation date")
+
+    # ========================================
+    # DISPATCH PERIOD (労働者派遣期間)
+    # ========================================
+    dispatch_start_date: date = Field(..., description="Start date of dispatch")
+    dispatch_end_date: date = Field(..., description="End date of dispatch")
+
+    # ========================================
+    # DISPATCH COMPANY (派遣元)
+    # ========================================
+    dispatch_company: CompanyInfo = Field(..., description="Dispatch origin company (UNS Kikaku)")
+    dispatch_manager: PersonInfo = Field(..., description="Dispatch origin manager (派遣元責任者)")
+    dispatch_complaint_handler: PersonInfo = Field(..., description="Complaint handler at dispatch company")
+
+    # ========================================
+    # CLIENT COMPANY (派遣先)
+    # ========================================
+    client_company: CompanyInfo = Field(..., description="Client/destination company")
+    client_manager: PersonInfo = Field(..., description="Client company manager (派遣先責任者)")
+    client_complaint_handler: PersonInfo = Field(..., description="Complaint handler at client company")
+
+    # ========================================
+    # WORKSITE DETAILS (就業場所)
+    # ========================================
+    worksite_name: str = Field(..., description="Name of worksite (may differ from company)")
+    worksite_address: str = Field(..., description="Physical address of worksite")
+    organizational_unit: Optional[str] = Field(None, description="Department/division (組織単位)")
+    production_line: Optional[str] = Field(None, description="Production line (ライン)")
+
+    # ========================================
+    # WORK CONTENT (業務内容)
+    # ========================================
+    work_content: str = Field(..., description="Detailed description of work to be performed")
+    responsibility_level: str = Field(
+        default="通常業務",
+        description="Level of responsibility (e.g., 通常業務, 管理業務)"
+    )
+
+    # ========================================
+    # SUPERVISION (指揮命令者)
+    # ========================================
+    supervisor: PersonInfo = Field(..., description="Person giving direct instructions")
+
+    # ========================================
+    # WORK SCHEDULE (就業時間)
+    # ========================================
+    schedule: WorkSchedule = Field(..., description="Work schedule details")
+
+    # ========================================
+    # COMPENSATION (派遣料金)
+    # ========================================
+    rates: RateInfo = Field(..., description="Compensation rates")
+
+    # ========================================
+    # EMPLOYEES (派遣労働者)
+    # ========================================
+    employees: List[EmployeeData] = Field(..., description="List of dispatched employees")
+    number_of_workers: int = Field(..., description="Total number of workers in this contract")
+
+    # ========================================
+    # SAFETY & WELFARE (安全衛生・福利厚生)
+    # ========================================
+    safety_measures: str = Field(
+        default="派遣先の安全衛生規程に従う",
+        description="Safety and health measures"
+    )
+    welfare_facilities: List[str] = Field(
+        default=["食堂", "更衣室", "休憩室"],
+        description="Available welfare facilities"
+    )
+
+    # ========================================
+    # LEGAL COMPLIANCE (法令遵守)
+    # ========================================
+    is_kyotei_taisho: bool = Field(default=False, description="Subject to kyotei (協定対象)")
+    is_mukeiko_60over_only: bool = Field(
+        default=False,
+        description="Only for age 60+ without employment contract (無期雇用60歳以上)"
+    )
+    is_direct_hire_prevention: bool = Field(
+        default=False,
+        description="Direct hire prevention clause (紹介予定派遣)"
+    )
+
+    # ========================================
+    # ADDITIONAL METADATA
+    # ========================================
+    notes: Optional[str] = Field(None, description="Additional notes or special conditions")
+    created_by: Optional[str] = Field(None, description="User who created this document")
+    version: str = Field(default="1.0", description="Document version")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "contract_number": "KOB-202512-0001",
+                "contract_date": "2025-12-01",
+                "dispatch_start_date": "2025-12-15",
+                "dispatch_end_date": "2026-12-14",
+                "dispatch_company": {
+                    "name": "UNS企画",
+                    "address": "東京都...",
+                    "tel": "03-1234-5678",
+                    "license_number": "派13-123456"
+                },
+                "client_company": {
+                    "name": "トヨタ自動車",
+                    "address": "愛知県豊田市...",
+                    "tel": "0565-12-3456"
+                },
+                "worksite_name": "豊田工場 第1製造部",
+                "worksite_address": "愛知県豊田市本社1-1",
+                "work_content": "自動車部品の組立作業",
+                "supervisor": {
+                    "name": "山田太郎",
+                    "department": "製造部",
+                    "position": "課長"
+                },
+                "schedule": {
+                    "work_days": ["月", "火", "水", "木", "金"],
+                    "work_start_time": "08:30",
+                    "work_end_time": "17:30",
+                    "break_time_minutes": 60
+                },
+                "rates": {
+                    "hourly_rate": 1500
+                },
+                "employees": [
+                    {
+                        "employee_number": "E001",
+                        "full_name": "田中花子",
+                        "full_name_kana": "タナカハナコ"
+                    }
+                ],
+                "number_of_workers": 1
+            }
+        }

--- a/backend/app/services/document_data_service.py
+++ b/backend/app/services/document_data_service.py
@@ -1,0 +1,256 @@
+"""
+Document Data Service - Converts ORM models to JSON format for document generation.
+
+This service acts as the bridge between database models and document generators.
+"""
+from datetime import date
+from typing import List
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from app.models.kobetsu_keiyakusho import KobetsuKeiyakusho
+from app.models.factory import Factory
+from app.models.employee import Employee
+from app.schemas.document_data import (
+    DocumentDataSchema,
+    CompanyInfo,
+    PersonInfo,
+    WorkSchedule,
+    RateInfo,
+    EmployeeData,
+)
+from app.core.config import settings
+
+
+class DocumentDataService:
+    """
+    Service for converting database models to document JSON format.
+
+    This provides a clean separation between data storage and document generation.
+    """
+
+    @staticmethod
+    def _get_dispatch_company_info() -> CompanyInfo:
+        """Get dispatch company (UNS Kikaku) info from settings."""
+        return CompanyInfo(
+            name=settings.COMPANY_NAME,
+            name_legal=settings.COMPANY_NAME_LEGAL,
+            postal_code=settings.COMPANY_POSTAL_CODE,
+            address=settings.COMPANY_ADDRESS,
+            tel=settings.COMPANY_TEL,
+            fax=settings.COMPANY_FAX,
+            email=settings.COMPANY_EMAIL,
+            license_number=settings.COMPANY_LICENSE_NUMBER,
+        )
+
+    @staticmethod
+    def _get_dispatch_manager() -> PersonInfo:
+        """Get dispatch origin manager from settings."""
+        return PersonInfo(
+            name=settings.DISPATCH_MANAGER_NAME,
+            position=settings.DISPATCH_MANAGER_POSITION,
+            department=settings.DISPATCH_RESPONSIBLE_DEPARTMENT,
+            phone=settings.DISPATCH_RESPONSIBLE_PHONE,
+        )
+
+    @staticmethod
+    def _get_dispatch_complaint_handler() -> PersonInfo:
+        """Get complaint handler at dispatch company."""
+        return PersonInfo(
+            name=settings.DISPATCH_COMPLAINT_NAME,
+            position=settings.DISPATCH_COMPLAINT_POSITION,
+            department=settings.DISPATCH_COMPLAINT_DEPARTMENT,
+            phone=settings.DISPATCH_COMPLAINT_PHONE,
+        )
+
+    @staticmethod
+    def _factory_to_company_info(factory: Factory) -> CompanyInfo:
+        """Convert Factory model to CompanyInfo."""
+        return CompanyInfo(
+            name=factory.company_name,
+            address=factory.company_address or "",
+            tel=factory.company_tel or "",
+            fax=factory.company_fax,
+            email=factory.company_email,
+        )
+
+    @staticmethod
+    def _create_person_from_data(
+        name: str = None,
+        department: str = None,
+        position: str = None,
+        phone: str = None,
+    ) -> PersonInfo:
+        """Create PersonInfo from individual fields."""
+        return PersonInfo(
+            name=name or "",
+            department=department,
+            position=position,
+            phone=phone,
+        )
+
+    @staticmethod
+    def _employee_to_employee_data(employee: Employee) -> EmployeeData:
+        """Convert Employee model to EmployeeData."""
+        return EmployeeData(
+            employee_number=employee.employee_number,
+            full_name=employee.full_name_kanji or employee.full_name,
+            full_name_kana=employee.full_name_katakana or "",
+            gender=employee.gender,
+            date_of_birth=employee.date_of_birth,
+            nationality=employee.nationality,
+            address=employee.current_address,
+            phone=employee.phone_number,
+        )
+
+    @classmethod
+    def from_kobetsu_contract(
+        cls,
+        contract: KobetsuKeiyakusho,
+        db: Session,
+    ) -> DocumentDataSchema:
+        """
+        Convert KobetsuKeiyakusho model to DocumentDataSchema (JSON).
+
+        Args:
+            contract: KobetsuKeiyakusho ORM instance
+            db: Database session for loading relationships
+
+        Returns:
+            DocumentDataSchema ready for document generation
+        """
+        # Load factory relationship if not loaded
+        factory = contract.factory
+
+        # Build schedule
+        schedule = WorkSchedule(
+            work_days=contract.work_days or ["月", "火", "水", "木", "金"],
+            work_start_time=contract.work_start_time,
+            work_end_time=contract.work_end_time,
+            break_time_minutes=contract.break_time_minutes or 60,
+            overtime_max_hours_day=contract.overtime_max_hours_day or 4,
+            overtime_max_hours_month=contract.overtime_max_hours_month or 45,
+        )
+
+        # Build rates
+        rates = RateInfo(
+            hourly_rate=contract.hourly_rate or Decimal("1500"),
+            overtime_rate=contract.overtime_rate,
+            holiday_rate=contract.holiday_work_rate,
+            night_shift_rate=contract.night_shift_rate,
+        )
+
+        # Build supervisor
+        supervisor = cls._create_person_from_data(
+            name=contract.supervisor_name,
+            department=contract.supervisor_department,
+            position=contract.supervisor_position,
+        )
+
+        # Build client managers (from contract fields)
+        client_manager = cls._create_person_from_data(
+            name=contract.haken_saki_manager_name,
+            phone=contract.haken_saki_manager_phone,
+        )
+
+        client_complaint_handler = cls._create_person_from_data(
+            name=contract.haken_saki_complaint_contact_name,
+            department=contract.haken_saki_complaint_contact_department,
+            phone=contract.haken_saki_complaint_contact_phone,
+        )
+
+        # Get employees
+        employees_data = []
+        if hasattr(contract, 'employees'):
+            employees_data = [
+                cls._employee_to_employee_data(emp)
+                for emp in contract.employees
+            ]
+
+        # Build final schema
+        return DocumentDataSchema(
+            # Contract identification
+            contract_number=contract.contract_number,
+            contract_date=contract.contract_date or date.today(),
+            document_date=date.today(),
+
+            # Dispatch period
+            dispatch_start_date=contract.dispatch_start_date,
+            dispatch_end_date=contract.dispatch_end_date,
+
+            # Dispatch company (UNS Kikaku)
+            dispatch_company=cls._get_dispatch_company_info(),
+            dispatch_manager=cls._get_dispatch_manager(),
+            dispatch_complaint_handler=cls._get_dispatch_complaint_handler(),
+
+            # Client company
+            client_company=cls._factory_to_company_info(factory),
+            client_manager=client_manager,
+            client_complaint_handler=client_complaint_handler,
+
+            # Worksite details
+            worksite_name=contract.worksite_name or factory.factory_name,
+            worksite_address=contract.worksite_address or factory.factory_address or "",
+            organizational_unit=contract.organizational_unit or factory.department,
+            production_line=factory.line,
+
+            # Work content
+            work_content=contract.work_content or "",
+            responsibility_level=contract.responsibility_level or "通常業務",
+
+            # Supervision
+            supervisor=supervisor,
+
+            # Schedule & rates
+            schedule=schedule,
+            rates=rates,
+
+            # Employees
+            employees=employees_data,
+            number_of_workers=len(employees_data) or contract.number_of_workers or 1,
+
+            # Safety & welfare
+            safety_measures=contract.safety_and_health_measures or "派遣先の安全衛生規程に従う",
+            welfare_facilities=contract.welfare_facilities or ["食堂", "更衣室", "休憩室"],
+
+            # Legal compliance
+            is_kyotei_taisho=contract.is_kyotei_taisho or False,
+            is_mukeiko_60over_only=contract.is_mukeiko_60over_only or False,
+            is_direct_hire_prevention=contract.is_direct_hire_prevention or False,
+
+            # Metadata
+            notes=contract.notes,
+            version="1.0",
+        )
+
+    @classmethod
+    def to_json_dict(cls, contract: KobetsuKeiyakusho, db: Session) -> dict:
+        """
+        Convert contract to plain JSON dict (for API responses).
+
+        Args:
+            contract: KobetsuKeiyakusho instance
+            db: Database session
+
+        Returns:
+            Plain dict that can be JSON serialized
+        """
+        schema = cls.from_kobetsu_contract(contract, db)
+        return schema.model_dump(mode='json')
+
+    @classmethod
+    def validate_json(cls, json_data: dict) -> DocumentDataSchema:
+        """
+        Validate JSON data against schema.
+
+        Args:
+            json_data: Dictionary to validate
+
+        Returns:
+            Validated DocumentDataSchema
+
+        Raises:
+            ValidationError: If data doesn't match schema
+        """
+        return DocumentDataSchema(**json_data)

--- a/backend/app/services/excel_generator_v2.py
+++ b/backend/app/services/excel_generator_v2.py
@@ -1,0 +1,300 @@
+"""
+Excel Generator V2 - Template-based generation using JSON data.
+
+This is the NEW approach: JSON → Excel Template → Filled Document
+
+Advantages:
+- Perfect formatting preservation
+- Easy to maintain (edit templates in Excel)
+- Fast generation
+- Compatible with original Excel system
+"""
+from datetime import date, time
+from decimal import Decimal
+from io import BytesIO
+from pathlib import Path
+from typing import Optional, Union
+
+from openpyxl import load_workbook
+from openpyxl.workbook import Workbook
+from openpyxl.worksheet.worksheet import Worksheet
+
+from app.core.config import settings
+from app.schemas.document_data import DocumentDataSchema
+
+
+class ExcelGeneratorV2:
+    """
+    Excel document generator using templates and JSON data.
+
+    This generator:
+    1. Loads a pre-formatted Excel template
+    2. Fills it with data from JSON (DocumentDataSchema)
+    3. Returns the completed document as bytes
+
+    Templates are stored in: backend/templates/excel/
+    """
+
+    def __init__(self, data: DocumentDataSchema):
+        """
+        Initialize generator with document data.
+
+        Args:
+            data: DocumentDataSchema (JSON format)
+        """
+        self.data = data
+        self.template_dir = Path(settings.EXCEL_TEMPLATE_DIR)
+
+    # ========================================
+    # FORMATTING HELPERS
+    # ========================================
+
+    def _format_date_japanese(self, d: Optional[date]) -> str:
+        """Format date as Japanese era (令和X年X月X日)."""
+        if d is None:
+            return ""
+
+        # Reiwa era started May 1, 2019
+        if d.year >= 2019 and (d.month > 4 or (d.month == 4 and d.year > 2019)):
+            reiwa_year = d.year - 2018
+            return f"令和{reiwa_year}年{d.month}月{d.day}日"
+
+        # Heisei era
+        if d.year >= 1989:
+            heisei_year = d.year - 1988
+            return f"平成{heisei_year}年{d.month}月{d.day}日"
+
+        return f"{d.year}年{d.month}月{d.day}日"
+
+    def _format_time(self, t: Optional[time]) -> str:
+        """Format time as HH:MM."""
+        if t is None:
+            return ""
+        return t.strftime("%H:%M")
+
+    def _format_time_range(self, start: Optional[time], end: Optional[time]) -> str:
+        """Format time range as HH:MM～HH:MM."""
+        start_str = self._format_time(start)
+        end_str = self._format_time(end)
+        if start_str and end_str:
+            return f"{start_str}～{end_str}"
+        return ""
+
+    def _format_currency(self, value: Optional[Union[Decimal, int, float]]) -> str:
+        """Format as Japanese yen (¥X,XXX)."""
+        if value is None:
+            return ""
+        return f"¥{int(value):,}"
+
+    def _format_work_days(self, days: list) -> str:
+        """Format work days list as string."""
+        if not days:
+            return "月・火・水・木・金"
+        return "・".join(days)
+
+    # ========================================
+    # TEMPLATE OPERATIONS
+    # ========================================
+
+    def _load_template(self, template_name: str) -> Workbook:
+        """Load Excel template from disk."""
+        template_path = self.template_dir / f"{template_name}.xlsx"
+
+        if not template_path.exists():
+            raise FileNotFoundError(
+                f"Template not found: {template_path}\n"
+                f"Please run: python backend/scripts/extract_templates.py"
+            )
+
+        return load_workbook(template_path)
+
+    def _replace_placeholders(self, ws: Worksheet, replacements: dict) -> None:
+        """
+        Replace placeholders in worksheet with actual values.
+
+        Searches for {{placeholder}} patterns and replaces them.
+        """
+        for row in ws.iter_rows():
+            for cell in row:
+                if cell.value and isinstance(cell.value, str):
+                    for placeholder, value in replacements.items():
+                        if placeholder in cell.value:
+                            cell.value = cell.value.replace(
+                                placeholder,
+                                str(value) if value is not None else ""
+                            )
+
+    def _workbook_to_bytes(self, wb: Workbook) -> bytes:
+        """Convert workbook to bytes for download."""
+        buffer = BytesIO()
+        wb.save(buffer)
+        buffer.seek(0)
+        return buffer.getvalue()
+
+    # ========================================
+    # DOCUMENT GENERATORS
+    # ========================================
+
+    def generate_kobetsu_keiyakusho(self) -> bytes:
+        """
+        Generate 個別契約書 (Individual Dispatch Contract).
+
+        Returns:
+            Excel file as bytes
+        """
+        wb = self._load_template("kobetsu_keiyakusho")
+        ws = wb.active
+
+        # Build replacement dictionary from JSON data
+        replacements = {
+            # Contract info
+            "{{contract_number}}": self.data.contract_number,
+            "{{contract_date}}": self._format_date_japanese(self.data.contract_date),
+            "{{document_date}}": self._format_date_japanese(self.data.document_date),
+
+            # Dispatch period
+            "{{dispatch_start}}": self._format_date_japanese(self.data.dispatch_start_date),
+            "{{dispatch_end}}": self._format_date_japanese(self.data.dispatch_end_date),
+
+            # Dispatch company (派遣元 - UNS Kikaku)
+            "{{dispatch_company}}": self.data.dispatch_company.name,
+            "{{dispatch_company_address}}": self.data.dispatch_company.address,
+            "{{dispatch_company_tel}}": self.data.dispatch_company.tel,
+            "{{license_number}}": self.data.dispatch_company.license_number or "",
+
+            # Client company (派遣先)
+            "{{client_company}}": self.data.client_company.name,
+            "{{client_address}}": self.data.client_company.address,
+            "{{client_tel}}": self.data.client_company.tel,
+
+            # Worksite (就業場所)
+            "{{worksite_name}}": self.data.worksite_name,
+            "{{worksite_address}}": self.data.worksite_address,
+            "{{organizational_unit}}": self.data.organizational_unit or "",
+
+            # Work content (業務内容)
+            "{{work_content}}": self.data.work_content,
+            "{{responsibility}}": self.data.responsibility_level,
+
+            # Supervisor (指揮命令者)
+            "{{supervisor_name}}": self.data.supervisor.name,
+            "{{supervisor_dept}}": self.data.supervisor.department or "",
+            "{{supervisor_position}}": self.data.supervisor.position or "",
+            "{{supervisor}}": self._format_supervisor(self.data.supervisor),
+
+            # Work schedule (就業時間)
+            "{{work_days}}": self._format_work_days(self.data.schedule.work_days),
+            "{{work_start}}": self._format_time(self.data.schedule.work_start_time),
+            "{{work_end}}": self._format_time(self.data.schedule.work_end_time),
+            "{{work_time}}": self._format_time_range(
+                self.data.schedule.work_start_time,
+                self.data.schedule.work_end_time
+            ),
+            "{{break_minutes}}": f"{self.data.schedule.break_time_minutes}分",
+
+            # Overtime (時間外労働)
+            "{{overtime_day}}": f"{self.data.schedule.overtime_max_hours_day}時間/日",
+            "{{overtime_month}}": f"{self.data.schedule.overtime_max_hours_month}時間/月",
+
+            # Rates (派遣料金)
+            "{{hourly_rate}}": self._format_currency(self.data.rates.hourly_rate),
+            "{{overtime_rate}}": self._format_currency(self.data.rates.overtime_rate),
+            "{{holiday_rate}}": self._format_currency(self.data.rates.holiday_rate),
+            "{{night_rate}}": self._format_currency(self.data.rates.night_shift_rate),
+
+            # Number of workers
+            "{{num_workers}}": f"{self.data.number_of_workers}名",
+
+            # Managers (責任者)
+            "{{dispatch_manager}}": self.data.dispatch_manager.name,
+            "{{dispatch_manager_phone}}": self.data.dispatch_manager.phone or "",
+            "{{client_manager}}": self.data.client_manager.name,
+            "{{client_manager_phone}}": self.data.client_manager.phone or "",
+
+            # Complaint handlers (苦情処理)
+            "{{dispatch_complaint_name}}": self.data.dispatch_complaint_handler.name,
+            "{{dispatch_complaint_phone}}": self.data.dispatch_complaint_handler.phone or "",
+            "{{client_complaint_name}}": self.data.client_complaint_handler.name,
+            "{{client_complaint_phone}}": self.data.client_complaint_handler.phone or "",
+
+            # Safety & welfare
+            "{{safety_measures}}": self.data.safety_measures,
+            "{{welfare}}": "・".join(self.data.welfare_facilities),
+
+            # Legal checkboxes
+            "{{kyotei_check}}": "☑" if self.data.is_kyotei_taisho else "☐",
+            "{{mukeiko_check}}": "☑" if self.data.is_mukeiko_60over_only else "☐",
+            "{{direct_hire_check}}": "☑" if self.data.is_direct_hire_prevention else "☐",
+        }
+
+        # Add employee data
+        for i, emp in enumerate(self.data.employees, start=1):
+            replacements[f"{{{{employee_{i}_name}}}}"] = emp.full_name
+            replacements[f"{{{{employee_{i}_kana}}}}"] = emp.full_name_kana
+            replacements[f"{{{{employee_{i}_number}}}}"] = emp.employee_number
+
+        # Apply replacements
+        self._replace_placeholders(ws, replacements)
+
+        return self._workbook_to_bytes(wb)
+
+    def _format_supervisor(self, person) -> str:
+        """Format supervisor as single string."""
+        parts = []
+        if person.department:
+            parts.append(person.department)
+        if person.position:
+            parts.append(person.position)
+        if person.name:
+            parts.append(person.name)
+        return " ".join(parts)
+
+    def generate_tsuchisho(self) -> bytes:
+        """Generate 通知書 (Notification)."""
+        wb = self._load_template("tsuchisho")
+        ws = wb.active
+
+        replacements = {
+            "{{notification_date}}": self._format_date_japanese(self.data.document_date),
+            "{{client_company}}": self.data.client_company.name,
+            "{{dispatch_company}}": self.data.dispatch_company.name,
+            "{{dispatch_address}}": self.data.dispatch_company.address,
+            "{{license_number}}": self.data.dispatch_company.license_number or "",
+            "{{dispatch_start}}": self._format_date_japanese(self.data.dispatch_start_date),
+            "{{dispatch_end}}": self._format_date_japanese(self.data.dispatch_end_date),
+            "{{worksite_name}}": self.data.worksite_name,
+            "{{work_content}}": self.data.work_content,
+            "{{work_time}}": self._format_time_range(
+                self.data.schedule.work_start_time,
+                self.data.schedule.work_end_time
+            ),
+        }
+
+        # Add employees
+        for i, emp in enumerate(self.data.employees, start=1):
+            replacements[f"{{{{emp_{i}_name}}}}"] = emp.full_name
+            replacements[f"{{{{emp_{i}_kana}}}}"] = emp.full_name_kana
+
+        self._replace_placeholders(ws, replacements)
+        return self._workbook_to_bytes(wb)
+
+    def generate_all(self) -> dict:
+        """
+        Generate all available documents.
+
+        Returns:
+            Dict mapping document name to bytes
+        """
+        results = {}
+
+        try:
+            results["kobetsu_keiyakusho"] = self.generate_kobetsu_keiyakusho()
+        except Exception as e:
+            results["kobetsu_keiyakusho_error"] = str(e)
+
+        try:
+            results["tsuchisho"] = self.generate_tsuchisho()
+        except Exception as e:
+            results["tsuchisho_error"] = str(e)
+
+        return results

--- a/backend/app/services/pdf_generator_v2.py
+++ b/backend/app/services/pdf_generator_v2.py
@@ -1,0 +1,226 @@
+"""
+PDF Generator V2 - Template-based generation using JSON data and Jinja2.
+
+This is the NEW approach: JSON → Jinja2 HTML Template → WeasyPrint → PDF
+
+Advantages:
+- Flexible design using HTML/CSS
+- Beautiful typography with Japanese fonts
+- Precise control over layout
+- Easy to maintain templates
+"""
+from datetime import date, time
+from decimal import Decimal
+from io import BytesIO
+from pathlib import Path
+from typing import Optional, Union
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from weasyprint import HTML, CSS
+
+from app.core.config import settings
+from app.schemas.document_data import DocumentDataSchema
+
+
+class PDFGeneratorV2:
+    """
+    PDF document generator using Jinja2 templates and WeasyPrint.
+
+    This generator:
+    1. Loads an HTML template (with Jinja2 syntax)
+    2. Renders it with data from JSON (DocumentDataSchema)
+    3. Converts HTML to PDF using WeasyPrint
+    4. Returns the PDF as bytes
+
+    Templates are stored in: backend/templates/pdf/
+    """
+
+    def __init__(self, data: DocumentDataSchema):
+        """
+        Initialize generator with document data.
+
+        Args:
+            data: DocumentDataSchema (JSON format)
+        """
+        self.data = data
+        self.template_dir = Path(settings.PDF_TEMPLATE_DIR)
+
+        # Setup Jinja2 environment
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(self.template_dir),
+            autoescape=select_autoescape(['html', 'xml'])
+        )
+
+        # Register custom filters
+        self.jinja_env.filters['format_date_japanese'] = self._format_date_japanese
+        self.jinja_env.filters['format_time'] = self._format_time
+        self.jinja_env.filters['format_currency'] = self._format_currency
+        self.jinja_env.filters['format_work_days'] = self._format_work_days
+
+    # ========================================
+    # FORMATTING HELPERS
+    # ========================================
+
+    def _format_date_japanese(self, d: Optional[date]) -> str:
+        """Format date as Japanese era (令和X年X月X日)."""
+        if d is None:
+            return ""
+
+        if d.year >= 2019 and (d.month > 4 or (d.month == 4 and d.year > 2019)):
+            reiwa_year = d.year - 2018
+            return f"令和{reiwa_year}年{d.month}月{d.day}日"
+
+        if d.year >= 1989:
+            heisei_year = d.year - 1988
+            return f"平成{heisei_year}年{d.month}月{d.day}日"
+
+        return f"{d.year}年{d.month}月{d.day}日"
+
+    def _format_time(self, t: Optional[time]) -> str:
+        """Format time as HH:MM."""
+        if t is None:
+            return ""
+        return t.strftime("%H:%M")
+
+    def _format_currency(self, value: Optional[Union[Decimal, int, float]]) -> str:
+        """Format as Japanese yen (¥X,XXX)."""
+        if value is None:
+            return ""
+        return f"¥{int(value):,}"
+
+    def _format_work_days(self, days: list) -> str:
+        """Format work days list."""
+        if not days:
+            return "月・火・水・木・金"
+        return "・".join(days)
+
+    # ========================================
+    # PDF GENERATION
+    # ========================================
+
+    def _render_html(self, template_name: str) -> str:
+        """
+        Render Jinja2 template with data.
+
+        Args:
+            template_name: Name of template file (e.g., 'kobetsu_keiyakusho.html')
+
+        Returns:
+            Rendered HTML string
+        """
+        template = self.jinja_env.get_template(template_name)
+        return template.render(data=self.data)
+
+    def _html_to_pdf(self, html_string: str) -> bytes:
+        """
+        Convert HTML string to PDF bytes using WeasyPrint.
+
+        Args:
+            html_string: Rendered HTML
+
+        Returns:
+            PDF file as bytes
+        """
+        # Load base CSS for Japanese documents
+        css_path = self.template_dir / "base.css"
+        css = None
+        if css_path.exists():
+            css = CSS(filename=str(css_path))
+
+        # Convert HTML to PDF
+        html = HTML(string=html_string, base_url=str(self.template_dir))
+        pdf_bytes = html.write_pdf(stylesheets=[css] if css else None)
+
+        return pdf_bytes
+
+    # ========================================
+    # DOCUMENT GENERATORS
+    # ========================================
+
+    def generate_kobetsu_keiyakusho(self) -> bytes:
+        """
+        Generate 個別契約書 (Individual Dispatch Contract) as PDF.
+
+        Returns:
+            PDF file as bytes
+        """
+        html = self._render_html("kobetsu_keiyakusho.html")
+        return self._html_to_pdf(html)
+
+    def generate_tsuchisho(self) -> bytes:
+        """
+        Generate 通知書 (Notification) as PDF.
+
+        Returns:
+            PDF file as bytes
+        """
+        html = self._render_html("tsuchisho.html")
+        return self._html_to_pdf(html)
+
+    def generate_daicho(self) -> bytes:
+        """
+        Generate DAICHO (Registry) as PDF.
+
+        Returns:
+            PDF file as bytes
+        """
+        html = self._render_html("daicho.html")
+        return self._html_to_pdf(html)
+
+    def generate_all(self) -> dict:
+        """
+        Generate all available documents as PDFs.
+
+        Returns:
+            Dict mapping document name to bytes
+        """
+        results = {}
+
+        try:
+            results["kobetsu_keiyakusho"] = self.generate_kobetsu_keiyakusho()
+        except Exception as e:
+            results["kobetsu_keiyakusho_error"] = str(e)
+
+        try:
+            results["tsuchisho"] = self.generate_tsuchisho()
+        except Exception as e:
+            results["tsuchisho_error"] = str(e)
+
+        try:
+            results["daicho"] = self.generate_daicho()
+        except Exception as e:
+            results["daicho_error"] = str(e)
+
+        return results
+
+
+# ========================================
+# CONVENIENCE FUNCTIONS
+# ========================================
+
+def generate_pdf_from_json(json_data: dict, document_type: str) -> bytes:
+    """
+    Generate PDF from JSON data.
+
+    Args:
+        json_data: Document data as dict
+        document_type: Type of document ('kobetsu_keiyakusho', 'tsuchisho', etc.)
+
+    Returns:
+        PDF bytes
+
+    Example:
+        >>> json_data = {"contract_number": "KOB-001", ...}
+        >>> pdf_bytes = generate_pdf_from_json(json_data, 'kobetsu_keiyakusho')
+    """
+    schema = DocumentDataSchema(**json_data)
+    generator = PDFGeneratorV2(schema)
+
+    if document_type == "kobetsu_keiyakusho":
+        return generator.generate_kobetsu_keiyakusho()
+    elif document_type == "tsuchisho":
+        return generator.generate_tsuchisho()
+    elif document_type == "daicho":
+        return generator.generate_daicho()
+    else:
+        raise ValueError(f"Unknown document type: {document_type}")

--- a/backend/templates/pdf/kobetsu_keiyakusho.html
+++ b/backend/templates/pdf/kobetsu_keiyakusho.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>労働者派遣個別契約書 - {{ data.contract_number }}</title>
+    <style>
+        @page {
+            size: A4;
+            margin: 2cm 2.5cm;
+        }
+
+        body {
+            font-family: "MS Mincho", "Yu Mincho", "Hiragino Mincho ProN", serif;
+            font-size: 10.5pt;
+            line-height: 1.6;
+            color: #000;
+        }
+
+        .title {
+            text-align: center;
+            font-size: 18pt;
+            font-weight: bold;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid #000;
+        }
+
+        .contract-info {
+            text-align: right;
+            margin-bottom: 20px;
+            font-size: 10pt;
+        }
+
+        .section {
+            margin-bottom: 15px;
+        }
+
+        .section-title {
+            font-weight: bold;
+            font-size: 11pt;
+            margin-bottom: 8px;
+            padding: 3px 8px;
+            background-color: #f0f0f0;
+            border-left: 4px solid #333;
+        }
+
+        .field {
+            margin-left: 15px;
+            margin-bottom: 5px;
+        }
+
+        .field-label {
+            font-weight: bold;
+            display: inline-block;
+            min-width: 150px;
+        }
+
+        .field-value {
+            display: inline-block;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 10px 0;
+        }
+
+        th, td {
+            border: 1px solid #333;
+            padding: 6px 8px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #e8e8e8;
+            font-weight: bold;
+        }
+
+        .signature-section {
+            margin-top: 30px;
+            page-break-inside: avoid;
+        }
+
+        .signature-box {
+            border: 1px solid #333;
+            padding: 15px;
+            margin-bottom: 15px;
+        }
+
+        .checkbox {
+            display: inline-block;
+            width: 15px;
+            height: 15px;
+            border: 1px solid #000;
+            margin-right: 5px;
+            text-align: center;
+            line-height: 15px;
+        }
+
+        .notes {
+            font-size: 9pt;
+            color: #666;
+            margin-top: 20px;
+            padding: 10px;
+            background-color: #f9f9f9;
+            border: 1px solid #ddd;
+        }
+    </style>
+</head>
+<body>
+    <div class="title">
+        労働者派遣個別契約書
+    </div>
+
+    <div class="contract-info">
+        <div>契約番号: {{ data.contract_number }}</div>
+        <div>契約日: {{ data.contract_date | format_date_japanese }}</div>
+    </div>
+
+    <!-- 第1条: 派遣期間 -->
+    <div class="section">
+        <div class="section-title">第1条 派遣期間</div>
+        <div class="field">
+            <span class="field-label">派遣期間:</span>
+            <span class="field-value">
+                {{ data.dispatch_start_date | format_date_japanese }} ～
+                {{ data.dispatch_end_date | format_date_japanese }}
+            </span>
+        </div>
+    </div>
+
+    <!-- 第2条: 派遣先企業 -->
+    <div class="section">
+        <div class="section-title">第2条 派遣先企業</div>
+        <div class="field">
+            <span class="field-label">会社名:</span>
+            <span class="field-value">{{ data.client_company.name }}</span>
+        </div>
+        <div class="field">
+            <span class="field-label">所在地:</span>
+            <span class="field-value">{{ data.client_company.address }}</span>
+        </div>
+        <div class="field">
+            <span class="field-label">電話番号:</span>
+            <span class="field-value">{{ data.client_company.tel }}</span>
+        </div>
+    </div>
+
+    <!-- 第3条: 就業場所 -->
+    <div class="section">
+        <div class="section-title">第3条 就業場所</div>
+        <div class="field">
+            <span class="field-label">就業場所名:</span>
+            <span class="field-value">{{ data.worksite_name }}</span>
+        </div>
+        <div class="field">
+            <span class="field-label">所在地:</span>
+            <span class="field-value">{{ data.worksite_address }}</span>
+        </div>
+        {% if data.organizational_unit %}
+        <div class="field">
+            <span class="field-label">組織単位:</span>
+            <span class="field-value">{{ data.organizational_unit }}</span>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- 第4条: 業務内容 -->
+    <div class="section">
+        <div class="section-title">第4条 業務内容</div>
+        <div class="field">
+            <span class="field-label">業務内容:</span>
+            <span class="field-value">{{ data.work_content }}</span>
+        </div>
+        <div class="field">
+            <span class="field-label">責任の程度:</span>
+            <span class="field-value">{{ data.responsibility_level }}</span>
+        </div>
+    </div>
+
+    <!-- 第5条: 指揮命令者 -->
+    <div class="section">
+        <div class="section-title">第5条 指揮命令者</div>
+        <div class="field">
+            <span class="field-label">氏名:</span>
+            <span class="field-value">{{ data.supervisor.name }}</span>
+        </div>
+        {% if data.supervisor.department %}
+        <div class="field">
+            <span class="field-label">所属部署:</span>
+            <span class="field-value">{{ data.supervisor.department }}</span>
+        </div>
+        {% endif %}
+        {% if data.supervisor.position %}
+        <div class="field">
+            <span class="field-label">役職:</span>
+            <span class="field-value">{{ data.supervisor.position }}</span>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- 第6条: 就業時間・休憩時間 -->
+    <div class="section">
+        <div class="section-title">第6条 就業時間・休憩時間</div>
+        <div class="field">
+            <span class="field-label">就業曜日:</span>
+            <span class="field-value">{{ data.schedule.work_days | format_work_days }}</span>
+        </div>
+        <div class="field">
+            <span class="field-label">就業時間:</span>
+            <span class="field-value">
+                {{ data.schedule.work_start_time | format_time }} ～
+                {{ data.schedule.work_end_time | format_time }}
+            </span>
+        </div>
+        <div class="field">
+            <span class="field-label">休憩時間:</span>
+            <span class="field-value">{{ data.schedule.break_time_minutes }}分</span>
+        </div>
+    </div>
+
+    <!-- 第7条: 時間外労働 -->
+    <div class="section">
+        <div class="section-title">第7条 時間外労働</div>
+        <div class="field">
+            <span class="field-label">1日の上限:</span>
+            <span class="field-value">{{ data.schedule.overtime_max_hours_day }}時間</span>
+        </div>
+        <div class="field">
+            <span class="field-label">1ヶ月の上限:</span>
+            <span class="field-value">{{ data.schedule.overtime_max_hours_month }}時間</span>
+        </div>
+    </div>
+
+    <!-- 第8条: 派遣料金 -->
+    <div class="section">
+        <div class="section-title">第8条 派遣料金</div>
+        <div class="field">
+            <span class="field-label">基本時給:</span>
+            <span class="field-value">{{ data.rates.hourly_rate | format_currency }}</span>
+        </div>
+        {% if data.rates.overtime_rate %}
+        <div class="field">
+            <span class="field-label">残業時給:</span>
+            <span class="field-value">{{ data.rates.overtime_rate | format_currency }}</span>
+        </div>
+        {% endif %}
+        {% if data.rates.holiday_rate %}
+        <div class="field">
+            <span class="field-label">休日時給:</span>
+            <span class="field-value">{{ data.rates.holiday_rate | format_currency }}</span>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- 第9条: 派遣労働者数 -->
+    <div class="section">
+        <div class="section-title">第9条 派遣労働者</div>
+        <div class="field">
+            <span class="field-label">派遣労働者数:</span>
+            <span class="field-value">{{ data.number_of_workers }}名</span>
+        </div>
+
+        {% if data.employees %}
+        <table>
+            <thead>
+                <tr>
+                    <th>社員番号</th>
+                    <th>氏名</th>
+                    <th>フリガナ</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for employee in data.employees %}
+                <tr>
+                    <td>{{ employee.employee_number }}</td>
+                    <td>{{ employee.full_name }}</td>
+                    <td>{{ employee.full_name_kana }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+    </div>
+
+    <!-- 第10条: 安全衛生 -->
+    <div class="section">
+        <div class="section-title">第10条 安全衛生</div>
+        <div class="field">
+            {{ data.safety_measures }}
+        </div>
+    </div>
+
+    <!-- 第11条: 福利厚生施設 -->
+    <div class="section">
+        <div class="section-title">第11条 福利厚生施設</div>
+        <div class="field">
+            {{ data.welfare_facilities | join('、') }}
+        </div>
+    </div>
+
+    <!-- 署名欄 -->
+    <div class="signature-section">
+        <div class="signature-box">
+            <strong>派遣元（甲）</strong><br>
+            {{ data.dispatch_company.name }}<br>
+            {{ data.dispatch_company.address }}<br>
+            電話: {{ data.dispatch_company.tel }}<br>
+            許可番号: {{ data.dispatch_company.license_number }}<br>
+            <br>
+            責任者: {{ data.dispatch_manager.name }}　印
+        </div>
+
+        <div class="signature-box">
+            <strong>派遣先（乙）</strong><br>
+            {{ data.client_company.name }}<br>
+            {{ data.client_company.address }}<br>
+            電話: {{ data.client_company.tel }}<br>
+            <br>
+            責任者: {{ data.client_manager.name }}　印
+        </div>
+    </div>
+
+    {% if data.notes %}
+    <div class="notes">
+        <strong>備考:</strong><br>
+        {{ data.notes }}
+    </div>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
Implements new architecture for generating legal dispatch documents:
- JSON schema as intermediate format (DocumentDataSchema)
- ORM to JSON converter service
- Excel generator using templates (openpyxl)
- PDF generator using Jinja2 + WeasyPrint
- New API endpoints for document generation
- HTML template example for kobetsu_keiyakusho
- Complete documentation in DOCUMENT_GENERATION_V2.md

Benefits:
- Separation of data and presentation
- Testable and maintainable
- Supports multiple output formats from same JSON
- Complies with 労働者派遣法第26条 (16 required fields)

Files added:
- backend/app/schemas/document_data.py
- backend/app/services/document_data_service.py
- backend/app/services/excel_generator_v2.py
- backend/app/services/pdf_generator_v2.py
- backend/app/api/v1/documents_v2.py
- backend/templates/pdf/kobetsu_keiyakusho.html
- DOCUMENT_GENERATION_V2.md